### PR TITLE
feat: warn via diagnostics when no schema found for a resource

### DIFF
--- a/lua/k8s-whisper.lua
+++ b/lua/k8s-whisper.lua
@@ -368,10 +368,19 @@ M.refresh_schemas = function(bufnr)
     end
   end
 
-  -- Set diagnostics for resources with no schema found
+  -- Set diagnostics and remove stale modelines for resources with no schema found
   if #unmatched > 0 then
     local diagnostics = {}
+    local modeline_pattern = '^#%s*yaml%-language%-server:%s*%$schema='
+    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
     for _, resource in ipairs(unmatched) do
+      -- Remove any existing modeline at this resource's start so yamlls stops trying to load it
+      local start_line = resource.start_line - 1 -- 0-indexed
+      if start_line < #lines and lines[start_line + 1] and lines[start_line + 1]:match(modeline_pattern) then
+        M.inserting_modelines[bufnr] = true
+        vim.api.nvim_buf_set_lines(bufnr, start_line, start_line + 1, false, {})
+        vim.defer_fn(function() M.inserting_modelines[bufnr] = nil end, 100)
+      end
       table.insert(diagnostics, {
         lnum = resource.start_line - 1,
         col = 0,

--- a/lua/k8s-whisper.lua
+++ b/lua/k8s-whisper.lua
@@ -309,8 +309,31 @@ M.insert_schema_modelines = function(bufnr, resource_schemas)
   end, 100)
 end
 
+-- Remove all yaml-language-server modelines from the buffer immediately
+M.clear_modelines = function(bufnr)
+  local modeline_pattern = '^#%s*yaml%-language%-server:%s*%$schema='
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local to_remove = {}
+  for i, line in ipairs(lines) do
+    if line:match(modeline_pattern) then
+      table.insert(to_remove, i - 1) -- collect 0-indexed line numbers
+    end
+  end
+  if #to_remove > 0 then
+    M.inserting_modelines[bufnr] = true
+    for i = #to_remove, 1, -1 do
+      vim.api.nvim_buf_set_lines(bufnr, to_remove[i], to_remove[i] + 1, false, {})
+    end
+    vim.defer_fn(function() M.inserting_modelines[bufnr] = nil end, 100)
+  end
+end
+
 -- Refresh schemas for a buffer (called on buffer changes)
 M.refresh_schemas = function(bufnr)
+  -- Strip all existing modelines immediately so yamlls does not try to load stale schema URLs
+  -- while the HTTP checks below are in progress
+  M.clear_modelines(bufnr)
+
   local buffer_content = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), '\n')
   local resource_schemas = {}
 
@@ -368,19 +391,10 @@ M.refresh_schemas = function(bufnr)
     end
   end
 
-  -- Set diagnostics and remove stale modelines for resources with no schema found
+  -- Set diagnostics for resources with no schema found
   if #unmatched > 0 then
     local diagnostics = {}
-    local modeline_pattern = '^#%s*yaml%-language%-server:%s*%$schema='
-    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
     for _, resource in ipairs(unmatched) do
-      -- Remove any existing modeline at this resource's start so yamlls stops trying to load it
-      local start_line = resource.start_line - 1 -- 0-indexed
-      if start_line < #lines and lines[start_line + 1] and lines[start_line + 1]:match(modeline_pattern) then
-        M.inserting_modelines[bufnr] = true
-        vim.api.nvim_buf_set_lines(bufnr, start_line, start_line + 1, false, {})
-        vim.defer_fn(function() M.inserting_modelines[bufnr] = nil end, 100)
-      end
       table.insert(diagnostics, {
         lnum = resource.start_line - 1,
         col = 0,

--- a/lua/k8s-whisper.lua
+++ b/lua/k8s-whisper.lua
@@ -391,22 +391,8 @@ M.refresh_schemas = function(bufnr)
     end
   end
 
-  -- Set diagnostics for resources with no schema found
-  if #unmatched > 0 then
-    local diagnostics = {}
-    for _, resource in ipairs(unmatched) do
-      table.insert(diagnostics, {
-        lnum = resource.start_line - 1,
-        col = 0,
-        severity = vim.diagnostic.severity.WARN,
-        message = 'No schema found for ' .. resource.kind .. ' (' .. resource.api_version .. ') — this resource is not validated',
-        source = 'k8s-whisper',
-      })
-    end
-    vim.diagnostic.set(ns, bufnr, diagnostics)
-  end
-
-  -- Insert modeline comments for each document
+  -- Insert modeline comments for matched resources first, then compute diagnostics
+  -- so line numbers account for the modelines that were inserted above each resource
   if #resource_schemas > 0 then
     M.insert_schema_modelines(bufnr, resource_schemas)
 
@@ -420,6 +406,29 @@ M.refresh_schemas = function(bufnr)
     else
       vim.notify('Attached ' .. #descriptions .. ' schemas: ' .. table.concat(descriptions, ', '), vim.log.levels.INFO)
     end
+  end
+
+  -- Set diagnostics for resources with no schema found.
+  -- Each matched resource whose start_line precedes this one caused a modeline insertion,
+  -- shifting the buffer down by one line — account for that in lnum.
+  if #unmatched > 0 then
+    local diagnostics = {}
+    for _, resource in ipairs(unmatched) do
+      local offset = 0
+      for _, rs in ipairs(resource_schemas) do
+        if rs.start_line < resource.start_line then
+          offset = offset + 1
+        end
+      end
+      table.insert(diagnostics, {
+        lnum = resource.start_line - 1 + offset,
+        col = 0,
+        severity = vim.diagnostic.severity.WARN,
+        message = 'No schema found for ' .. resource.kind .. ' (' .. resource.api_version .. ') — this resource is not validated',
+        source = 'k8s-whisper',
+      })
+    end
+    vim.diagnostic.set(ns, bufnr, diagnostics)
   end
 end
 

--- a/lua/k8s-whisper.lua
+++ b/lua/k8s-whisper.lua
@@ -20,6 +20,8 @@ local M = {
   inserting_modelines = {}, -- Track when we're inserting modelines to prevent refresh loops
 }
 
+local ns = vim.api.nvim_create_namespace('k8s-whisper')
+
 -- Setup function to configure the plugin
 M.setup = function(opts)
   opts = opts or {}
@@ -312,14 +314,17 @@ M.refresh_schemas = function(bufnr)
   local buffer_content = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), '\n')
   local resource_schemas = {}
 
+  -- Clear previous diagnostics for this buffer
+  vim.diagnostic.reset(ns, bufnr)
+
   -- Extract all resources with their line numbers
   local resources = M.extract_api_version_and_kind(buffer_content)
   if not resources or #resources == 0 then
-    vim.notify('No Kubernetes resources found in this file', vim.log.levels.WARN)
     return
   end
 
   local all_crds = M.list_github_tree()
+  local unmatched = {}
 
   -- Match each resource to its schema
   for _, resource in ipairs(resources) do
@@ -330,9 +335,13 @@ M.refresh_schemas = function(bufnr)
     local crd_name = M.normalize_crd_name(resource.api_version, resource.kind)
     if crd_name then
       for _, crd in ipairs(all_crds) do
-        if crd:match(crd_name) then
-          schema_url = M.schema_url .. '/' .. crd
-          description = resource.kind .. ' (' .. resource.api_version .. ')'
+        if crd:find(crd_name, 1, true) then
+          local candidate_url = M.schema_url .. '/' .. crd
+          local response = curl.get(candidate_url, { headers = M.config.github_headers })
+          if response.status == 200 then
+            schema_url = candidate_url
+            description = resource.kind .. ' (' .. resource.api_version .. ')'
+          end
           break
         end
       end
@@ -347,14 +356,31 @@ M.refresh_schemas = function(bufnr)
       end
     end
 
-    -- Add to resource_schemas if we found a schema
+    -- Add to resource_schemas if we found a schema, otherwise track as unmatched
     if schema_url then
       table.insert(resource_schemas, {
         start_line = resource.start_line,
         schema_url = schema_url,
         description = description,
       })
+    else
+      table.insert(unmatched, resource)
     end
+  end
+
+  -- Set diagnostics for resources with no schema found
+  if #unmatched > 0 then
+    local diagnostics = {}
+    for _, resource in ipairs(unmatched) do
+      table.insert(diagnostics, {
+        lnum = resource.start_line - 1,
+        col = 0,
+        severity = vim.diagnostic.severity.WARN,
+        message = 'No schema found for ' .. resource.kind .. ' (' .. resource.api_version .. ') — this resource is not validated',
+        source = 'k8s-whisper',
+      })
+    end
+    vim.diagnostic.set(ns, bufnr, diagnostics)
   end
 
   -- Insert modeline comments for each document
@@ -371,8 +397,6 @@ M.refresh_schemas = function(bufnr)
     else
       vim.notify('Attached ' .. #descriptions .. ' schemas: ' .. table.concat(descriptions, ', '), vim.log.levels.INFO)
     end
-  else
-    vim.notify('No schemas found for any resources in this file', vim.log.levels.WARN)
   end
 end
 
@@ -426,6 +450,7 @@ M.init = function(bufnr)
     buffer = bufnr,
     callback = function()
       M.clear_schemas(bufnr)
+      vim.diagnostic.reset(ns, bufnr)
       if M.refresh_timers[bufnr] then
         vim.fn.timer_stop(M.refresh_timers[bufnr])
         M.refresh_timers[bufnr] = nil

--- a/plugin/whisper.lua
+++ b/plugin/whisper.lua
@@ -1,4 +1,12 @@
 
+-- Strip stale modelines before the LSP attaches so yamlls never sees an invalid $schema URL
+vim.api.nvim_create_autocmd('BufReadPost', {
+  pattern = { '*.yaml', '*.yml' },
+  callback = function(args)
+    require('k8s-whisper').clear_modelines(args.buf)
+  end,
+})
+
 vim.api.nvim_create_autocmd('FileType', {
   pattern = 'yaml',
   callback = function(args)


### PR DESCRIPTION
Replace noisy vim.notify warnings with per-resource diagnostics so the user knows when a YAML resource is not being validated. 
Also verify CRD schema URLs exist (HTTP 200) before attaching them to avoid yamlls errors on missing manifests, and fix CRD pattern matching to use plain string search instead of Lua patterns.